### PR TITLE
osc: output control signals

### DIFF
--- a/mixer/src/Meter_Module.C
+++ b/mixer/src/Meter_Module.C
@@ -115,9 +115,9 @@ Meter_Module::update ( void )
 
 	const float v = CO_DB( control_value[i] );
 	
-    // use loudest channel for public meter level
-    if ( v > dB )
-        dB = v;
+        // use loudest channel for public meter level
+        if ( v > dB )
+            dB = v;
 
 	if ( v > o->value() )
 	    o->value( v );

--- a/mixer/src/Module.C
+++ b/mixer/src/Module.C
@@ -1396,10 +1396,13 @@ Module::handle_chain_name_changed ( )
     }
     for ( int i = 0; i < ncontrol_outputs(); ++i )
     {
-        if ( control_output[i].connected() )
-            control_output[i].connected_port()->module()->handle_chain_name_changed();
         if ( control_output[i].name() != NULL )
+        {
+            if ( control_output[i].connected() )
+                control_output[i].connected_port()->module()->handle_chain_name_changed();
+
             control_output[i].update_osc_port();
+        }
     }
 
     if ( ! chain()->strip()->group()->single() )

--- a/mixer/src/Module.C
+++ b/mixer/src/Module.C
@@ -756,7 +756,10 @@ Module::Port::osc_control_change_cv ( float v, void *user_data )
 int
 Module::Port::osc_control_update_signals ( void *user_data )
 {
+
     Module::Port *p = (Module::Port*)user_data;
+
+    Fl:lock()
 
     float f = p->control_value();
 

--- a/mixer/src/Module.C
+++ b/mixer/src/Module.C
@@ -759,7 +759,7 @@ Module::Port::osc_control_update_signals ( void *user_data )
 
     Module::Port *p = (Module::Port*)user_data;
 
-    Fl:lock()
+    Fl::lock();
 
     float f = p->control_value();
 

--- a/mixer/src/Module.H
+++ b/mixer/src/Module.H
@@ -198,6 +198,7 @@ public:
 
         static int osc_control_change_exact ( float v, void *user_data );
         static int osc_control_change_cv ( float v, void *user_data );
+        static int osc_control_update_signals ( void *user_data );
 
         Hints hints;
 
@@ -303,6 +304,7 @@ public:
         
 #endif
         OSC::Signal *scaled_signal ( void ) { return _scaled_signal; }
+        OSC::Signal *unscaled_signal ( void ) { return _unscaled_signal; }
 
         int _by_number_number;
         char *_by_number_path;

--- a/mixer/src/midi-mapper.C
+++ b/mixer/src/midi-mapper.C
@@ -572,7 +572,7 @@ load_settings ( void )
 
             sig_map[midi_event] = m;
             sig_map[midi_event].signal_name = signal_name;
-            sig_map[midi_event].signal = osc->add_signal( signal_name, OSC::Signal::Output, 0, 1, 0, signal_handler, &sig_map[midi_event] );
+            sig_map[midi_event].signal = osc->add_signal( signal_name, OSC::Signal::Output, 0, 1, 0, signal_handler, NULL, &sig_map[midi_event] );
 
 	    sig_map_ordered[max_signal] = midi_event;
         }
@@ -895,7 +895,7 @@ void emit_signal_for_event ( const char *midi_event, midievent &e, struct nrpn_s
 	m->signal_name = s;
 	m->signal =
 	    osc->add_signal( s, OSC::Signal::Output, 0, 1, 0,
-			     signal_handler,
+			     signal_handler, NULL,
 			     m );
 
 	sig_map_ordered[max_signal] = midi_event;

--- a/nonlib/OSC/Endpoint.H
+++ b/nonlib/OSC/Endpoint.H
@@ -131,6 +131,7 @@ namespace OSC
     };
 
     typedef int (*signal_handler) ( float value, void *user_data );
+    typedef int (*signal_feedback_handler) ( void *user_data );
 
     class Signal
     {
@@ -163,6 +164,7 @@ namespace OSC
         Direction _direction;
 
         signal_handler _handler;
+        signal_feedback_handler _feedback_handler;
         void *_user_data;
         Parameter_Limits _parameter_limits;
         
@@ -203,6 +205,7 @@ namespace OSC
 
         /* publishes value to targets */
         void value ( float v );
+        void value_no_callback ( float v );
         /* get current value */
         float value ( void ) const { return _value; }
 
@@ -350,7 +353,7 @@ namespace OSC
 //        bool connect_signal ( OSC::Signal *s, const char *peer_name, int signal_id );
         bool connect_signal ( OSC::Signal *s, const char *peer_and_path );
 
-        Signal * add_signal ( const char *path, Signal::Direction dir, float min, float max, float default_value, signal_handler handler, void *user_data );
+        Signal * add_signal ( const char *path, Signal::Direction dir, float min, float max, float default_value, signal_handler handler, signal_feedback_handler feedback_handler, void *user_data );
         Method *add_method ( const char *path, const char *typespec, lo_method_handler handler, void *user_data, const char *argument_description );
         void del_method ( const char *path, const char *typespec );
         void del_method ( Method* method );


### PR DESCRIPTION
This PR addresses the features mentioned in #3 by doing the following changes:
 - create signals for output controls
 - update signals values when a query is received (message with no value) before sending the reply
 - add output control for meter level (returns the loudest channel's level)

It doesn't update nor send feedback for output signal on every value change because it may happen at a very high rate and there's no throttling mechanism (although some comments in the code indicates there had been plan to implement one). So far this simple query approach worked just fine for me.