### PR TITLE
osc: accept incoming values as integers

### DIFF
--- a/nonlib/OSC/Endpoint.C
+++ b/nonlib/OSC/Endpoint.C
@@ -734,6 +734,11 @@ namespace OSC
 //                    DMESSAGE( "recording value %f", argv[0]->f );
                     i->second.current_value = argv[0]->f;
                 }
+                if ( !strcmp(types, "i" ))
+                {
+//                    DMESSAGE( "recording value %i", argv[0]->i );
+                    i->second.current_value = argv[0]->i;
+                }
 
 		/* FIXME: this was intended to break feedback cycles, but it actually
 		 results in some feedback values not being sent at all */

--- a/nonlib/OSC/Endpoint.C
+++ b/nonlib/OSC/Endpoint.C
@@ -569,6 +569,12 @@ namespace OSC
             o = (Signal*)user_data;
             f = argv[0]->f;
         }
+        else if ( ! strcmp( types, "i" ) )
+        {
+            /* accept a value for signal named in path */
+            o = (Signal*)user_data;
+            f = argv[0]->i;
+        }
         else if ( ! types || 0 == types[0] )
         {
             /* reply with current value */


### PR DESCRIPTION
A very common and frustrating error, especially for newcomers, is to send integers when floats are expected. Being that strict here doesn't make sense, this PR adheres to the moto "be strict in what you send, flexible in what you receive" and will likely make life simpler :)