### PR TITLE
ui: ctrl-w to close plugin window

### DIFF
--- a/mixer/src/Module_Parameter_Editor.C
+++ b/mixer/src/Module_Parameter_Editor.C
@@ -945,6 +945,15 @@ Module_Parameter_Editor::handle ( int m )
                 }
                 return 0;
             }
+        case FL_KEYBOARD:
+        {
+            if ( (Fl::event_key(FL_Control_L) || Fl::event_key(FL_Control_R)) && Fl::event_key(119) )
+            {
+                // ctrl + w -> close editor
+                hide();
+                return 1;
+            }
+        }
     
     }
     


### PR DESCRIPTION
This add the common keyboard shortcut for closing windows to ladspa plugins. It would be nice to have it for lv2 external ui's as well, but I'm not sure where and how to do it.