### PR TITLE
Osc signal infos

### DIFF
--- a/mixer/src/Module.C
+++ b/mixer/src/Module.C
@@ -659,6 +659,7 @@ Module::Port::change_osc_path ( char *path )
                                                               &Module::Port::osc_control_change_cv,
                                                               &Module::Port::osc_control_update_signals,
                                                               this );
+            _scaled_signal->set_infos(name(), hints.type);
 
             _scaled_signal->connection_state_callback( handle_signal_connection_state_changed, this );
 
@@ -668,6 +669,7 @@ Module::Port::change_osc_path ( char *path )
                                                                 &Module::Port::osc_control_change_exact,
                                                                 &Module::Port::osc_control_update_signals,
                                                                 this );
+            _unscaled_signal->set_infos(name(), hints.type);
         }
         else
         {

--- a/nonlib/OSC/Endpoint.C
+++ b/nonlib/OSC/Endpoint.C
@@ -621,11 +621,11 @@ namespace OSC
             if (! strcmp( o->path(), &argv[0]->s) )
             {
                 ((Endpoint*)user_data)->send( lo_message_get_source( msg ), "/reply", path, o->path(), o->_parameter_infos.type, o->_parameter_infos.label );
+                return 0;
             }
         }
 
-        ((Endpoint*)user_data)->send( lo_message_get_source( msg ), "/reply", path );
-
+        ((Endpoint*)user_data)->send( lo_message_get_source( msg ), "/reply", path, &argv[0]->s);
 
         return 0;
     }

--- a/nonlib/OSC/Endpoint.H
+++ b/nonlib/OSC/Endpoint.H
@@ -116,6 +116,12 @@ namespace OSC
         float max;
         float default_value;
     };
+    struct Parameter_Infos
+    {
+        const char *label;
+        int type;
+    };
+
 
     class Endpoint;
     class Signal;
@@ -167,6 +173,7 @@ namespace OSC
         signal_feedback_handler _feedback_handler;
         void *_user_data;
         Parameter_Limits _parameter_limits;
+        Parameter_Infos _parameter_infos;
         
         void (*_connection_state_callback)(OSC::Signal *, void*);
         void *_connection_state_userdata;
@@ -211,6 +218,8 @@ namespace OSC
 
         bool is_connected_to ( const Signal *s ) const;
         
+        void set_infos ( const char *label, int type );
+
         friend class Endpoint;
     };
 
@@ -284,6 +293,7 @@ namespace OSC
         static int osc_sig_disconnect ( const char *path, const char *types, lo_arg **argv, int argc, lo_message msg, void *user_data );
         static int osc_sig_connect ( const char *path, const char *types, lo_arg **argv, int argc, lo_message msg, void *user_data );
         static int osc_sig_hello ( const char *path, const char *types, lo_arg **argv, int argc, lo_message msg, void *user_data );
+        static int osc_sig_infos ( const char *path, const char *types, lo_arg **argv, int argc, lo_message msg, void *user_data );
 
 
         Peer * add_peer ( const char *name, const char *url );
@@ -409,6 +419,10 @@ namespace OSC
         int send ( lo_address to, const char *path, const char *v1, const char *v2, int v3, float v4, float v5, float v6 );
 
         int send ( lo_address to, const char *path, const char *v1, const char *v2, const char *v3, int v4, float v5, float v6, float v7 );
+
+        // reply signature for /signal/infos
+        int send ( lo_address to, const char *path, const char *v1, const char *v2, int v3, const char *v4 );
+
 
         void peer_scan_complete_callback ( void(*_cb)(void*), void *userdata) 
             {


### PR DESCRIPTION
This PR adds an osc method for retrieving a extra infos on a signal to help generating remote control surfaces, for now only type and name are returned but it could be extended easily if needed.