### PR TITLE
osc: do not prepend instance name to osc paths when session managed

### DIFF
--- a/nonlib/OSC/Endpoint.C
+++ b/nonlib/OSC/Endpoint.C
@@ -90,10 +90,8 @@ namespace OSC
     }
 
     void
-    Signal::rename ( const char *path )
+    Signal::rename ( const char *new_path )
     {
-        char *new_path;
-        asprintf( &new_path, "%s%s", _endpoint->name() ? _endpoint->name() : "", path );
 
         DMESSAGE( "Renaming signal %s to %s", this->path(), new_path );
 
@@ -113,7 +111,7 @@ namespace OSC
         _endpoint->rename_translation_destination( _path, new_path );
 
         free( _path );
-        _path = new_path;
+        _path = strdup(new_path);
     }
 
     void
@@ -1148,12 +1146,8 @@ namespace OSC
     Signal *
     Endpoint::add_signal ( const char *path, Signal::Direction dir, float min, float max, float default_value, signal_handler handler, signal_feedback_handler feedback_handler, void *user_data )
     {
-        char *s;
-        asprintf( &s, "%s%s", name() ? name() : "", path );
 
-        Signal *o = new Signal( s, dir );
-        
-        free(s);
+        Signal *o = new Signal( path, dir );
 
         o->_handler = handler;
         o->_feedback_handler = feedback_handler;


### PR DESCRIPTION
When non mixer is nsm-managed, it prepends all osc paths with the instance name, for example
`/strip/kick/Gain/Mute'
becomes
`Non-Mixer-XT.instanceName/strip/kick/Gain/Mute' 
where `instanceName`  is the name provided in the --instance-name cli argument.

While this most certainly made sense in the non-daw ecosystem, it doesn't comply with the open sound control specification (paths must begin with a `/`) and not all libraries allow sending messages without a leading slash (liblo does, but it's not the only implementation out there). 

Once again, I assumed the nm-xt project doesn't aim to keep compatibility with non-timeline, and is leaning toward a standalone mixer solution (I use it only in modular/jack-powered live setups). If that's not the case, then this PR should probably not be merged. If that's the case, then I'll probably undertake more changes in the future to make the osc api more public and specific to nm-xt (the original implementation was mostly designed as a private api to allow non-apps to interact altogether).
