### PR TITLE
osc: make plugin bypass state controllable

### DIFF
--- a/mixer/src/Gain_Module.C
+++ b/mixer/src/Gain_Module.C
@@ -63,6 +63,7 @@ Gain_Module::Gain_Module ( )
         p.hints.maximum = 1.0f;
         p.hints.minimum = 0.0f;
         p.hints.dimensions = 1;
+        p.hints.visible = false;
         p.connect_to( _bypass );
         add_port( p );
     }

--- a/mixer/src/Gain_Module.C
+++ b/mixer/src/Gain_Module.C
@@ -64,6 +64,7 @@ Gain_Module::Gain_Module ( )
         p.hints.minimum = 0.0f;
         p.hints.dimensions = 1;
         p.hints.visible = false;
+        p.hints.invisible_with_signals = true;
         p.connect_to( _bypass );
         add_port( p );
     }

--- a/mixer/src/Gain_Module.C
+++ b/mixer/src/Gain_Module.C
@@ -56,6 +56,17 @@ Gain_Module::Gain_Module ( )
         add_port( p );
     }
 
+    {
+        Port p( this, Port::INPUT, Port::CONTROL, "dsp/bypass" );
+        p.hints.type = Port::Hints::BOOLEAN;
+        p.hints.ranged = true;
+        p.hints.maximum = 1.0f;
+        p.hints.minimum = 0.0f;
+        p.hints.dimensions = 1;
+        p.connect_to( _bypass );
+        add_port( p );
+    }
+
     end();
 
     log_create();

--- a/mixer/src/LADSPA_Plugin.C
+++ b/mixer/src/LADSPA_Plugin.C
@@ -270,6 +270,18 @@ LADSPA_Plugin::load_plugin(unsigned long id)
                 DMESSAGE( "Plugin has control port \"%s\" (default: %f)", _idata->descriptor->PortNames[ i ], p.hints.default_value );
             }
         }
+
+        if (bypassable()) {
+            Port pb( this, Port::INPUT, Port::CONTROL, "dsp/bypass" );
+            pb.hints.type = Port::Hints::BOOLEAN;
+            pb.hints.ranged = true;
+            pb.hints.maximum = 1.0f;
+            pb.hints.minimum = 0.0f;
+            pb.hints.dimensions = 1;
+            pb.connect_to( _bypass );
+            add_port( pb );
+        }
+
     }
     else
     {
@@ -436,7 +448,7 @@ LADSPA_Plugin::activate ( void )
         for ( unsigned int i = 0; i < _idata->handle.size(); ++i )
             _idata->descriptor->activate( _idata->handle[i] );
 
-    _bypass = false;
+    *_bypass = 0.0f;
 
     if ( chain() )
         chain()->client()->unlock();
@@ -453,7 +465,7 @@ LADSPA_Plugin::deactivate( void )
     if ( chain() )
         chain()->client()->lock();
 
-    _bypass = true;
+    *_bypass = 1.0f;
 
     if ( _idata->descriptor->deactivate )
         for ( unsigned int i = 0; i < _idata->handle.size(); ++i )

--- a/mixer/src/LADSPA_Plugin.C
+++ b/mixer/src/LADSPA_Plugin.C
@@ -278,6 +278,7 @@ LADSPA_Plugin::load_plugin(unsigned long id)
             pb.hints.maximum = 1.0f;
             pb.hints.minimum = 0.0f;
             pb.hints.dimensions = 1;
+            pb.hints.visible = false;
             pb.connect_to( _bypass );
             add_port( pb );
         }

--- a/mixer/src/LADSPA_Plugin.C
+++ b/mixer/src/LADSPA_Plugin.C
@@ -279,6 +279,7 @@ LADSPA_Plugin::load_plugin(unsigned long id)
             pb.hints.minimum = 0.0f;
             pb.hints.dimensions = 1;
             pb.hints.visible = false;
+            pb.hints.invisible_with_signals = true;
             pb.connect_to( _bypass );
             add_port( pb );
         }

--- a/mixer/src/LADSPA_Plugin.H
+++ b/mixer/src/LADSPA_Plugin.H
@@ -41,7 +41,7 @@ public:
     void handle_port_connection_change ( void );
     void resize_buffers ( nframes_t buffer_size );
 
-    virtual bool bypass ( void ) const { return _bypass; }
+    virtual bool bypass ( void ) const { return *_bypass == 1.0f; }
     virtual void bypass ( bool v );
 
 private:

--- a/mixer/src/LV2_Plugin.C
+++ b/mixer/src/LV2_Plugin.C
@@ -1031,6 +1031,7 @@ LV2_Plugin::load_plugin ( const char* uri )
             pb.hints.maximum = 1.0f;
             pb.hints.minimum = 0.0f;
             pb.hints.dimensions = 1;
+            pb.hints.visible = false;
             pb.connect_to( _bypass );
             add_port( pb );
         }

--- a/mixer/src/LV2_Plugin.C
+++ b/mixer/src/LV2_Plugin.C
@@ -1023,6 +1023,19 @@ LV2_Plugin::load_plugin ( const char* uri )
                 DMESSAGE( "Plugin has control port \"%s\" (default: %f)", rdfport.Name, p.hints.default_value );
             }
         }
+
+        if (bypassable()) {
+            Port pb( this, Port::INPUT, Port::CONTROL, "dsp/bypass" );
+            pb.hints.type = Port::Hints::BOOLEAN;
+            pb.hints.ranged = true;
+            pb.hints.maximum = 1.0f;
+            pb.hints.minimum = 0.0f;
+            pb.hints.dimensions = 1;
+            pb.connect_to( _bypass );
+            add_port( pb );
+        }
+
+
     }
     else
     {
@@ -1600,7 +1613,7 @@ LV2_Plugin::activate ( void )
         }
     }
 
-    _bypass = false;
+    *_bypass = 0.0f;
 
     if ( chain() )
         chain()->client()->unlock();
@@ -1617,7 +1630,7 @@ LV2_Plugin::deactivate( void )
     if ( chain() )
         chain()->client()->lock();
 
-    _bypass = true;
+    *_bypass = 1.0f;
 
     if ( _idata->lv2.descriptor->deactivate )
     {

--- a/mixer/src/LV2_Plugin.C
+++ b/mixer/src/LV2_Plugin.C
@@ -1032,6 +1032,7 @@ LV2_Plugin::load_plugin ( const char* uri )
             pb.hints.minimum = 0.0f;
             pb.hints.dimensions = 1;
             pb.hints.visible = false;
+            pb.hints.invisible_with_signals = true;
             pb.connect_to( _bypass );
             add_port( pb );
         }

--- a/mixer/src/LV2_Plugin.H
+++ b/mixer/src/LV2_Plugin.H
@@ -73,7 +73,7 @@ public:
     void handle_sample_rate_change ( nframes_t sample_rate );
     void resize_buffers ( nframes_t buffer_size );
 
-    virtual bool bypass ( void ) const { return _bypass; }
+    virtual bool bypass ( void ) const { return *_bypass == 1.0f; }
     virtual void bypass ( bool v );
 
 #ifdef PRESET_SUPPORT

--- a/mixer/src/Module.C
+++ b/mixer/src/Module.C
@@ -202,7 +202,6 @@ Module::init ( void )
     _chain = 0;
     _instances = 1;
     _bypass = new float(0);
-    // *_bypass = 0.0f;
     _base_label = NULL;
     _number = -2;	/* magic number indicates old instance, before numbering */
     _is_lv2 = false;

--- a/mixer/src/Module.C
+++ b/mixer/src/Module.C
@@ -201,7 +201,8 @@ Module::init ( void )
     _editor = 0;
     _chain = 0;
     _instances = 1;
-    _bypass = 0;
+    _bypass = new float(0);
+    // *_bypass = 0.0f;
     _base_label = NULL;
     _number = -2;	/* magic number indicates old instance, before numbering */
     _is_lv2 = false;

--- a/mixer/src/Module.C
+++ b/mixer/src/Module.C
@@ -609,7 +609,7 @@ Module::Port::generate_osc_path ()
 
     // /strip/STRIPNAME/MODULENAME/CONTROLNAME
 
-    if ( ! p->hints.visible )
+    if ( ! p->hints.visible && ! p->hints.invisible_with_signals)
     {
         return NULL;
     }

--- a/mixer/src/Module.H
+++ b/mixer/src/Module.H
@@ -90,7 +90,7 @@ protected:
 
     Module_Parameter_Editor *_editor;
 
-    volatile bool _bypass;
+    float * _bypass;
 
 public:
 
@@ -625,8 +625,8 @@ public:
             return n;
         }
 
-    virtual bool bypass ( void ) const { return _bypass; }
-    virtual void bypass ( bool v ) { _bypass = v; }
+    virtual bool bypass ( void ) const { return *_bypass == 1.0f; }
+    virtual void bypass ( bool v ) { *_bypass = (float)v; }
 
     virtual bool bypassable ( void ) const
         {

--- a/mixer/src/Module.H
+++ b/mixer/src/Module.H
@@ -182,6 +182,7 @@ public:
             float current_value;
             int dimensions;
             bool visible;
+            bool invisible_with_signals;
             uint32_t plug_port_index;     ///< plugin Index of port control
             std::vector<EnumeratorScalePoints>ScalePoints;
 
@@ -197,6 +198,7 @@ public:
                     current_value = 0.0f;
                     dimensions = 1;
                     visible = true;
+                    invisible_with_signals = false;
                     plug_port_index = 0;
                 }
         };

--- a/mixer/src/Module_Parameter_Editor.C
+++ b/mixer/src/Module_Parameter_Editor.C
@@ -273,6 +273,7 @@ Module_Parameter_Editor::make_controls ( void )
 
     for (unsigned int i = 0; i < module->control_input.size(); ++i )
     {
+        // ignore hidden bypass parameter
         if (i == module->control_input.size() - 1 && module->bypassable())
             continue;
 
@@ -563,6 +564,7 @@ Module_Parameter_Editor::update_control_visibility ( void )
 {
     for ( unsigned int i = 0; i < _module->control_input.size(); ++i )
     {
+        // ignore hidden bypass parameter
         if (i == _module->control_input.size() - 1 && _module->bypassable())
             continue;
 
@@ -767,6 +769,10 @@ Module_Parameter_Editor::handle_control_changed ( Module::Port *p )
 {
     int i = _module->control_input_port_index( p );
    
+    // ignore hidden bypass parameter
+    if (i == (int)_module->control_input.size() - 1 && _module->bypassable())
+        return;
+
     Fl_Widget *w = controls_by_port[i];
 
     if ( i == azimuth_port_number ||

--- a/mixer/src/Module_Parameter_Editor.C
+++ b/mixer/src/Module_Parameter_Editor.C
@@ -273,10 +273,6 @@ Module_Parameter_Editor::make_controls ( void )
 
     for (unsigned int i = 0; i < module->control_input.size(); ++i )
     {
-        // ignore hidden bypass parameter
-        if (i == module->control_input.size() - 1 && module->bypassable())
-            continue;
-
         Fl_Widget *w;
 
         Module::Port *p = &module->control_input[i];
@@ -564,10 +560,6 @@ Module_Parameter_Editor::update_control_visibility ( void )
 {
     for ( unsigned int i = 0; i < _module->control_input.size(); ++i )
     {
-        // ignore hidden bypass parameter
-        if (i == _module->control_input.size() - 1 && _module->bypassable())
-            continue;
-
         const Module::Port *p = &_module->control_input[i];
 
         if ( p->hints.visible )
@@ -769,10 +761,6 @@ Module_Parameter_Editor::handle_control_changed ( Module::Port *p )
 {
     int i = _module->control_input_port_index( p );
    
-    // ignore hidden bypass parameter
-    if (i == (int)_module->control_input.size() - 1 && _module->bypassable())
-        return;
-
     Fl_Widget *w = controls_by_port[i];
 
     if ( i == azimuth_port_number ||

--- a/mixer/src/Module_Parameter_Editor.C
+++ b/mixer/src/Module_Parameter_Editor.C
@@ -273,6 +273,9 @@ Module_Parameter_Editor::make_controls ( void )
 
     for (unsigned int i = 0; i < module->control_input.size(); ++i )
     {
+        if (i == module->control_input.size() - 1 && module->bypassable())
+            continue;
+
         Fl_Widget *w;
 
         Module::Port *p = &module->control_input[i];
@@ -560,6 +563,9 @@ Module_Parameter_Editor::update_control_visibility ( void )
 {
     for ( unsigned int i = 0; i < _module->control_input.size(); ++i )
     {
+        if (i == _module->control_input.size() - 1 && _module->bypassable())
+            continue;
+
         const Module::Port *p = &_module->control_input[i];
 
         if ( p->hints.visible )

--- a/mixer/src/Plugin_Module.C
+++ b/mixer/src/Plugin_Module.C
@@ -68,7 +68,8 @@ Plugin_Module::init ( void )
     _latency = 0;
     _last_latency = 0;
     /* module will be bypassed until plugin is loaded */
-    _bypass = true;
+    *((float*)_bypass) = 1.0f;
+
     _crosswire = false;
 
     align( (Fl_Align)FL_ALIGN_CENTER | FL_ALIGN_INSIDE );

--- a/mixer/src/Plugin_Module.H
+++ b/mixer/src/Plugin_Module.H
@@ -117,7 +117,7 @@ public:
     void configure_midi_outputs ();
 #endif
 
-    virtual bool bypass ( void ) const { return _bypass; }
+    virtual bool bypass ( void ) const { return *_bypass == 1.0f; }
     virtual void bypass ( bool /*v*/ ){};
 
     virtual void process ( nframes_t ){};


### PR DESCRIPTION
A rather opinionated change... if I remember correctly non's author was against implementing that, but I had to give it a try : after all what's the difference between (un)bypassing a plugin from the UI and doing it with an osc message ? As it happens, it seems to *just* work, and opens some cool possibilities. 

The only drawback I can think of is that changing bypass states would affects the DSP load and that's something you wanna be careful with in live situations.

The extra signal's path contains a slash to prevent conflicts with plugin parameter symbols.