### PR TITLE
osc: don't send a closing /reply for /signal/infos

### DIFF
--- a/nonlib/OSC/Endpoint.C
+++ b/nonlib/OSC/Endpoint.C
@@ -624,8 +624,6 @@ namespace OSC
             }
         }
 
-        ((Endpoint*)user_data)->send( lo_message_get_source( msg ), "/reply", path, &argv[0]->s);
-
         return 0;
     }
 


### PR DESCRIPTION
Since there is only one reply message per query, no closing /reply is needed to indicate the reply is complete.